### PR TITLE
Allow using alternatives repository for mesos

### DIFF
--- a/recipes/_debian_scheduler.rb
+++ b/recipes/_debian_scheduler.rb
@@ -1,5 +1,5 @@
 # Add Aurora repository
-include_recipe 'mesos::repo'
+include_recipe 'mesos::repo' if node['mesos']['repo']
 include_recipe 'aurora::repo'
 
 # Install Aurora

--- a/recipes/_rhel_scheduler.rb
+++ b/recipes/_rhel_scheduler.rb
@@ -1,5 +1,5 @@
 # Add (Mesos & Aurora) required repositories
-include_recipe 'mesos::repo'
+include_recipe 'mesos::repo' if node['mesos']['repo']
 include_recipe 'aurora::repo'
 
 # Install aurora-scheduler package

--- a/recipes/_rhel_slave.rb
+++ b/recipes/_rhel_slave.rb
@@ -1,5 +1,5 @@
 # Add (Mesos & Aurora) required repositories
-include_recipe 'mesos::repo'
+include_recipe 'mesos::repo' if node['mesos']['repo']
 include_recipe 'aurora::repo'
 
 # Install aurora-executor package


### PR DESCRIPTION
By checking for mesos.repo attribute, we do the same thing done in the
mesos cookbook, allowing to use alternative repositories.

@FlorentFlament 
