### PR TITLE
Thermos executor should support something else than ZK announcer

### DIFF
--- a/recipes/_common_scheduler.rb
+++ b/recipes/_common_scheduler.rb
@@ -37,10 +37,10 @@ end
 
 ruby_block 'set thermos_executor flags' do
   block do
-    node.default['aurora']['scheduler']['app_config']['thermos_executor_flags'] =
+    node.default['aurora']['scheduler']['app_config']['thermos_executor_flags'] <<
       if node['aurora']['thermos']['announcer_enable']
         [
-          '--announcer-enable',
+          ' --announcer-enable',
           "--announcer-ensemble=#{node['aurora']['thermos']['zk_announce_endpoints']}",
           "--announcer-serverset-path=#{node['aurora']['thermos']['zk_announce_path']}"
         ].join(' ')


### PR DESCRIPTION
Right now, we are completely unable to make something else than `--anouncer (...)`at Thermos level.

In this commit we simply append announcer config to existing one.

cc: @FlorentFlament @komuta @guilhem  